### PR TITLE
Allow to not set base_uri in clients configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Add the `m6web_guzzlehttp` section in your configuration file. Here is the minim
 # app/config/config.yml
 m6web_guzzlehttp:
     clients:
-        default:
+        default: ~
+        other:
             base_uri: "http://domain.tld/"
 ```
 
@@ -57,19 +58,24 @@ Then you can ask container for your client :
 ```php
 // in a controller
 
-$client = $this->get('m6web_guzzlehttp');
+$client = $this->get('m6web_guzzlehttp'); // default client
+
 try {
-    $response = $client->get('path/to/resource'); // call http://domain.tld/path/to/resource
+    $response = $client->get('http://domain.tld/path/to/resource');
     
     $promises = [
-        'first' => $client->getAsync('path/to/resource'),
-        'second' => $client->getAsync('http://other.domain.tld/path/to/resource')
+        'first' => $client->getAsync('http://domain.tld/path/to/resource'),
+        'second' => $client->getAsync('http://domain.tld/path/to/other/resource')
     ];
     
     $result = \GuzzleHttp\Promise\unwrap($promises);
 } catch(\GuzzleHttp\Exception\ConnectException $e) {
     // connection problem like timeout
-} 
+}
+
+// use other client
+$otherClient = $this->get('m6web_guzzlehttp_other');
+$response = $otherClient->get('path/to/resource'); // call http://domain.tld/path/to/resource
 ```
 
 The service return a configured guzzle client, for more information on how to use it, you can read the [guzzle6 documentation](http://guzzle.readthedocs.org/en/latest/index.html).
@@ -154,7 +160,7 @@ For more information on how to setup the RedisBundle, refer to the README in the
 m6web_guzzlehttp:
     clients:
         default:
-            base_uri: ""                     # required. Base uri
+            base_uri: ""                     # Base uri to prepend on request uri
             timeout: 5.0                     # request timeout
             http_errors: true                # enable or disable exception on http errors
             allow_redirects: true            # enable or disable follow redirect

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,7 +28,7 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('id', false)
                     ->prototype('array')
                         ->children()
-                            ->scalarNode('base_uri')->isRequired()->end()
+                            ->scalarNode('base_uri')->defaultValue("")->end()
                             ->floatNode('timeout')->defaultValue(5.0)->end()
                             ->booleanNode('http_errors')->defaultValue(true)->end()
                             ->booleanNode('allow_redirects')->defaultValue(true)->end()

--- a/tests/Fixtures/default-config.yml
+++ b/tests/Fixtures/default-config.yml
@@ -1,4 +1,3 @@
 m6web_guzzlehttp:
     clients:
-        default:
-            base_uri: "http://domain.tld"
+        default: ~

--- a/tests/Units/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/tests/Units/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -22,7 +22,7 @@ class M6WebGuzzleHttpExtension extends test
             ->array($arguments = $container->getDefinition('m6web_guzzlehttp')->getArgument(0))
                 ->hasSize(8)
             ->string($arguments['base_uri'])
-                ->isEqualTo('http://domain.tld')
+                ->isEqualTo('')
             ->float($arguments['timeout'])
                 ->isEqualTo(5.0)
             ->boolean($arguments['http_errors'])


### PR DESCRIPTION
With this fix we can have a simpler client's configuration 