### PR TITLE
Fix: cache client problem

### DIFF
--- a/src/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/src/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -92,6 +92,8 @@ class M6WebGuzzleHttpExtension extends Extension
      */
     protected function setGuzzleProxyHandler(ContainerBuilder $container, $clientId, array $config)
     {
+        // arguments in handler factories below represents the maximum number of idle handles.
+        // the values are the default defined in guzzle CurlHanddler and CurlMultiHandler
         $handlerFactorySync = new Definition('%m6web_guzlehttp.handler.curlfactory.class%');
         $handlerFactorySync->setArguments([3]);
 

--- a/src/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/src/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -49,9 +49,12 @@ class M6WebGuzzleHttpExtension extends Extension
         }
         unset($config['redirects']);
 
+       $this->setGuzzleProxyHandler($container, $clientId, $config);
+
         $handlerStackDefinition = new Definition('%m6web_guzzlehttp.guzzle.handlerstack.class%');
         $handlerStackDefinition->setFactory(['%m6web_guzzlehttp.guzzle.handlerstack.class%', 'create']);
-        $handlerStackDefinition->setArguments([new Reference('m6web_guzzlehttp.guzzle.proxyhandler')]);
+        $handlerStackDefinition->setArguments([new Reference('m6web_guzzlehttp.guzzle.proxyhandler_'.$clientId)]);
+
         $container->setDefinition('m6web_guzzlehttp.guzzle.handlerstack.'.$clientId, $handlerStackDefinition);
 
         $handlerStackReference = new Reference('m6web_guzzlehttp.guzzle.handlerstack.'.$clientId);
@@ -68,17 +71,7 @@ class M6WebGuzzleHttpExtension extends Extension
             $config['curl'] = $this->getCurlConfig($config);
         }
 
-        if (array_key_exists('guzzlehttp_cache', $config)) {
-            $defaultTtl = $config['guzzlehttp_cache']['default_ttl'];
-            $headerTtl = $config['guzzlehttp_cache']['use_header_ttl'];
-            $cacheService = new Reference($config['guzzlehttp_cache']['service']);
 
-            $curlHandler = $container->getDefinition('m6web_guzlehttp.handler.curlhandler');
-            $curlMultiHandler = $container->getDefinition('m6web_guzlehttp.handler.curlmultihandler');
-
-            $curlHandler->addMethodCall('setCache', [$cacheService, $defaultTtl, $headerTtl]);
-            $curlMultiHandler->addMethodCall('setCache', [$cacheService, $defaultTtl, $headerTtl]);
-        }
 
 
         $guzzleClientDefintion = new Definition('%m6web_guzzlehttp.guzzle.client.class%');
@@ -88,6 +81,45 @@ class M6WebGuzzleHttpExtension extends Extension
 
         $container->setDefinition($containerKey, $guzzleClientDefintion);
 
+    }
+
+    /**
+     * Set proxy handler definition for the client
+     *
+     * @param ContainerBuilder $container
+     * @param string           $clientId
+     * @param array            $config
+     */
+    protected function setGuzzleProxyHandler(ContainerBuilder $container, $clientId, array $config)
+    {
+        $handlerFactorySync = new Definition('%m6web_guzlehttp.handler.curlfactory.class%');
+        $handlerFactorySync->setArguments([3]);
+
+        $handlerFactoryNormal = new Definition('%m6web_guzlehttp.handler.curlfactory.class%');
+        $handlerFactoryNormal->setArguments([50]);
+
+        $curlhandler = new Definition('%m6web_guzlehttp.handler.curlhandler.class%');
+        $curlhandler->setArguments([ ['handle_factory' => $handlerFactorySync] ]);
+        $curlhandler->addMethodCall('setDebug', [$container->getParameter('kernel.debug')]);
+
+        $curlMultihandler = new Definition('%m6web_guzlehttp.handler.curlmultihandler.class%');
+        $curlMultihandler->setArguments([ ['handle_factory' => $handlerFactoryNormal] ]);
+        $curlMultihandler->addMethodCall('setDebug', [$container->getParameter('kernel.debug')]);
+
+        if (array_key_exists('guzzlehttp_cache', $config)) {
+            $defaultTtl = $config['guzzlehttp_cache']['default_ttl'];
+            $headerTtl = $config['guzzlehttp_cache']['use_header_ttl'];
+            $cacheService = new Reference($config['guzzlehttp_cache']['service']);
+
+            $curlhandler->addMethodCall('setCache', [$cacheService, $defaultTtl, $headerTtl]);
+            $curlMultihandler->addMethodCall('setCache', [$cacheService, $defaultTtl, $headerTtl]);
+        }
+
+        $proxyHandler = new Definition('%m6web_guzzlehttp.guzzle.proxyhandler.class%');
+        $proxyHandler->setFactory(['%m6web_guzzlehttp.guzzle.proxyhandler.class%', 'wrapSync']);
+        $proxyHandler->setArguments([$curlMultihandler, $curlhandler]);
+
+        $container->setDefinition('m6web_guzzlehttp.guzzle.proxyhandler_'.$clientId, $proxyHandler);
     }
 
     protected function getCurlConfig(array $config)

--- a/src/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/src/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -92,7 +92,7 @@ class M6WebGuzzleHttpExtension extends Extension
      */
     protected function setGuzzleProxyHandler(ContainerBuilder $container, $clientId, array $config)
     {
-        // arguments in handler factories below represents the maximum number of idle handles.
+        // arguments (3 and 50) in handler factories below represents the maximum number of idle handles.
         // the values are the default defined in guzzle CurlHanddler and CurlMultiHandler
         $handlerFactorySync = new Definition('%m6web_guzlehttp.handler.curlfactory.class%');
         $handlerFactorySync->setArguments([3]);

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -11,28 +11,5 @@ parameters:
     m6web_guzzlehttp.middleware.eventdispatcher.class: M6Web\Bundle\GuzzleHttpBundle\Middleware\EventDispatcherMiddleware
 
 services:
-    m6web_guzlehttp.handler.curlfactory.sync:
-        class: %m6web_guzlehttp.handler.curlfactory.class%
-        arguments: [3]
 
-    m6web_guzlehttp.handler.curlfactory.normal:
-        class: %m6web_guzlehttp.handler.curlfactory.class%
-        arguments: [50]
-
-    m6web_guzlehttp.handler.curlhandler:
-        class: %m6web_guzlehttp.handler.curlhandler.class%
-        arguments: [ {handle_factory: "@m6web_guzlehttp.handler.curlfactory.sync"} ]
-        calls: [ ['setDebug', [%kernel.debug%]] ]
-
-    m6web_guzlehttp.handler.curlmultihandler:
-        class: %m6web_guzlehttp.handler.curlmultihandler.class%
-        arguments: [ {handle_factory : "@m6web_guzlehttp.handler.curlfactory.normal"} ]
-        calls: [ ['setDebug', [%kernel.debug%]] ]
-
-    m6web_guzzlehttp.guzzle.proxyhandler:
-        class: %m6web_guzzlehttp.guzzle.proxyhandler.class%
-        factory: [%m6web_guzzlehttp.guzzle.proxyhandler.class%, wrapSync]
-        arguments:
-            - "@m6web_guzlehttp.handler.curlmultihandler"
-            - "@m6web_guzlehttp.handler.curlhandler"
 

--- a/tests/Fixtures/cache-config.yml
+++ b/tests/Fixtures/cache-config.yml
@@ -1,0 +1,14 @@
+m6web_guzzlehttp:
+    clients:
+        default:
+            base_uri: "http://domain.tld"
+            guzzlehttp_cache:
+                default_ttl: 100
+                use_header_ttl: false
+                service: cache_service
+        myclient:
+            base_uri: "http://domain2.tld"
+            guzzlehttp_cache:
+                default_ttl: 300
+                use_header_ttl: true
+                service: cache_service2


### PR DESCRIPTION
With multi-client  config, cache setting was not individual but inherit from the last client setting.

This fix #9  resolve this issue by dynamically build the proxy handler required by guzzle.