### PR TITLE
Feature/default headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,10 +174,16 @@ m6web_guzzlehttp:
                 service: my_cache_service    # reference to service who implements the cache interface
                 default_ttl: 3600            # defautl ttl for cache entry in seconds
                 use_header_ttl: false        # use the cache-control header to set the ttl
+            default_headers:                 # optionnal. Default request headers
+                User_Agent: "m6web/1.0"      # set header "User-Agent" with the value "m6web/1.0"
+                header\_name: "my value"     # set header "header_name" with value "my value"
                 
         otherclient:
             ...
 ```
+
+For the `default_headers` options, the key in array represent the header name. The underscore will be transformed to hyphen
+ except if is escaped by a backslash.
 
 ## Contributing
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -55,6 +55,10 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('service')->cannotBeEmpty()->end()
                                 ->end()
                             ->end()
+                            ->arrayNode('default_headers')
+                                ->useAttributeAsKey('headerKey', true)
+                                ->prototype('scalar')->end()
+                            ->end() // end arrayNode('default_headers')
                         ->end()
                     ->end() // end prototype
                 ->end()

--- a/src/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/src/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -72,7 +72,21 @@ class M6WebGuzzleHttpExtension extends Extension
         }
 
 
+        // process default headers if set
+        if (!empty($config['default_headers'])) {
+            $headers = [];
+            array_walk($config['default_headers'], function ($value, $key) use (&$headers) {
+                // replace underscore by hyphen in key
+                $key = preg_replace('`(?<!\\\)_`', '-', $key);
+                // replace escaped underscore by underscore
+                $key = str_replace('\\_', '_', $key);
 
+                $headers[$key] = $value;
+            });
+
+            $config['headers'] = $headers;
+        }
+        unset($config['default_headers']);
 
         $guzzleClientDefintion = new Definition('%m6web_guzzlehttp.guzzle.client.class%');
         $guzzleClientDefintion->addArgument($config);

--- a/tests/Fixtures/multiclient-config.yml
+++ b/tests/Fixtures/multiclient-config.yml
@@ -6,3 +6,5 @@ m6web_guzzlehttp:
             allow_redirects: false
         myclient:
             base_uri: "http://domain2.tld"
+            default_headers:
+                User_Agent: "Towel/1.0"

--- a/tests/Fixtures/override-config.yml
+++ b/tests/Fixtures/override-config.yml
@@ -11,3 +11,8 @@ m6web_guzzlehttp:
                 strict: true
                 referer: false
                 protocols: ["http"]
+            default_headers:
+                User_Agent: "Towel/1.0"
+                X_Question: "The Ultimate Question of Life, the Universe and Everything"
+                X_Answer: 42
+                Escape\_Underscore: "Why not?"

--- a/tests/Units/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/tests/Units/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -65,7 +65,7 @@ class M6WebGuzzleHttpExtension extends test
             ->boolean($container->has('m6web_guzzlehttp'))
                 ->isTrue()
             ->array($arguments = $container->getDefinition('m6web_guzzlehttp')->getArgument(0))
-                ->hasSize(7)
+                ->hasSize(8)
             ->string($arguments['base_uri'])
                 ->isEqualTo('http://domain.tld')
             ->integer($arguments['timeout'])
@@ -86,6 +86,17 @@ class M6WebGuzzleHttpExtension extends test
             ->array($redirect['protocols'])
                 ->hasSize(1)
                 ->isEqualTo(['http'])
+            ->array($headers = $arguments['headers'])
+                ->hasSize(4)
+                ->hasKeys(['User-Agent', 'X-Question', 'X-Answer', 'Escape_Underscore'])
+            ->string($headers['User-Agent'])
+                ->isEqualTo('Towel/1.0')
+            ->string($headers['X-Question'])
+                ->isEqualTo('The Ultimate Question of Life, the Universe and Everything')
+            ->integer($headers['X-Answer'])
+                ->isEqualTo(42)
+            ->string($headers['Escape_Underscore'])
+                ->isEqualTo('Why not?')
         ;
     }
 
@@ -110,7 +121,7 @@ class M6WebGuzzleHttpExtension extends test
             ->boolean($container->has('m6web_guzzlehttp_myclient'))
                 ->isTrue()
             ->array($arguments = $container->getDefinition('m6web_guzzlehttp_myclient')->getArgument(0))
-                ->hasSize(8)
+                ->hasSize(9)
             ->string($arguments['base_uri'])
                 ->isEqualTo('http://domain2.tld')
             ->float($arguments['timeout'])
@@ -127,6 +138,9 @@ class M6WebGuzzleHttpExtension extends test
             ->array($redirect['protocols'])
                 ->hasSize(2)
                 ->isEqualTo(['http', 'https'])
+            ->array($headers = $arguments['headers'])
+                ->hasSize(1)
+                ->hasKey('User-Agent')
         ;
     }
 
@@ -178,6 +192,29 @@ class M6WebGuzzleHttpExtension extends test
         $this
             ->object($client = $container->get('m6web_guzzlehttp'))
                 ->isInstanceOf('\GuzzleHttp\Client')
+        ;
+    }
+
+    public function testClietnConfigurationWithHeaders()
+    {
+        $container = $this->getContainerForConfiguation('override-config');
+        $container->compile();
+
+        $this
+            ->object($client = $container->get('m6web_guzzlehttp'))
+                ->isInstanceOf('\GuzzleHttp\Client')
+            ->array($config = $client->getConfig())
+                ->hasKey('headers')
+            ->array($headers = $config['headers'])
+                ->hasKeys(['User-Agent', 'X-Question', 'X-Answer', 'Escape_Underscore'])
+            ->string($headers['User-Agent'])
+                ->isEqualTo('Towel/1.0')
+            ->string($headers['X-Question'])
+                ->isEqualTo('The Ultimate Question of Life, the Universe and Everything')
+            ->integer($headers['X-Answer'])
+                ->isEqualTo(42)
+            ->string($headers['Escape_Underscore'])
+                ->isEqualTo('Why not?')
         ;
     }
 


### PR DESCRIPTION
This pr allowing setting default headers for the request like this : 

```yaml
myclient:
    default_headers:
        User_Agent: "m6web/1.0"
        X\_Answer: 42
```
The config above result of setting headers :
 - User-Agent
 - X_Answer

Underscore are changed to hyphen. Escape underscore to keep it in the name.

Close #11 