### PR TITLE
Add client name in request event

### DIFF
--- a/src/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/src/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -60,7 +60,7 @@ class M6WebGuzzleHttpExtension extends Extension
         $handlerStackReference = new Reference('m6web_guzzlehttp.guzzle.handlerstack.'.$clientId);
 
         $middlewareEventDispatcherDefinition = new Definition('%m6web_guzzlehttp.middleware.eventdispatcher.class%');
-        $middlewareEventDispatcherDefinition->setArguments([new Reference('event_dispatcher')]);
+        $middlewareEventDispatcherDefinition->setArguments([new Reference('event_dispatcher'), $clientId]);
         $middlewareEventDispatcherDefinition->addMethodCall('push', [$handlerStackReference]);
 
         // we must assign middleware for build process

--- a/src/EventDispatcher/GuzzleHttpEvent.php
+++ b/src/EventDispatcher/GuzzleHttpEvent.php
@@ -37,6 +37,11 @@ class GuzzleHttpEvent extends Event
     protected $response;
 
     /**
+     * @var string
+     */
+    protected $clientId;
+
+    /**
      * Set request
      *
      * @param Request $request
@@ -133,5 +138,29 @@ class GuzzleHttpEvent extends Event
     public function getTiming()
     {
         return $this->getExecutionTime() * 1000;
+    }
+
+    /**
+     * Get client ID
+     *
+     * @return string
+     */
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+    /**
+     * Set client ID
+     *
+     * @param string $clientId
+     *
+     * @return GuzzleHttpEvent
+     */
+    public function setClientId($clientId)
+    {
+        $this->clientId = $clientId;
+
+        return $this;
     }
 }

--- a/src/Middleware/EventDispatcherMiddleware.php
+++ b/src/Middleware/EventDispatcherMiddleware.php
@@ -28,15 +28,22 @@ class EventDispatcherMiddleware implements MiddlewareInterface
     protected $events;
 
     /**
+     * @var string
+     */
+    protected $clientId;
+
+    /**
      * Constructor
      *
      * @param EventDispatcherInterface $eventDispatcher
+     * @param string                   $clientId
      */
-    public function __construct(EventDispatcherInterface $eventDispatcher)
+    public function __construct(EventDispatcherInterface $eventDispatcher, $clientId)
     {
 
         $this->eventDispatcher = $eventDispatcher;
         $this->events = [];
+        $this->clientId = $clientId;
     }
 
     /**
@@ -96,6 +103,7 @@ class EventDispatcherMiddleware implements MiddlewareInterface
         $event = new GuzzleHttpEvent();
         $event->setExecutionStart();
         $event->setRequest($request);
+        $event->setClientId($this->clientId);
 
         $this->events[$this->getEventKey($request)] = $event;
     }


### PR DESCRIPTION
For monitoring purpose, we need to know from which client event is thrown.