### PR TITLE
Avoid unserialize issues

### DIFF
--- a/src/Handler/CacheTrait.php
+++ b/src/Handler/CacheTrait.php
@@ -130,11 +130,16 @@ trait CacheTrait
     protected function getCached(RequestInterface $request)
     {
         $cacheKey = self::getKey($request);
-        if (!$this->cache->has($cacheKey)) {
+        if (is_null($cachedContent = $this->cache->get($cacheKey))) {
             return null;
         }
 
-        $cached = unserialize($this->cache->get($cacheKey));
+        $cached = unserialize($cachedContent);
+        foreach ($cached as $value) {
+            if (is_null($value)) {
+                return null;
+            }
+        }
 
         // rebuild response with cache entry : status, headers, body, protocol version, reason
         $response = new Response($cached[0], $cached[1], $cached[2], $cached[3], $cached[4]);


### PR DESCRIPTION
Sometimes we get this error :
```
Catchable Fatal Error: Argument 2 passed to GuzzleHttp\Psr7\Response::__construct()
must be of the type array, null given, called in 
[...]vendor/m6web/guzzle-http-bundle/src/Handler/CacheTrait.php on line 140 and defined
```
There might be an issue when data are unserialized from cache.   That's why I add a check on unserialized data.