### PR TITLE
Fix event dispatcher memory leak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
   - 5.6
   - 7
 
+before_script:
+  - phpenv config-rm xdebug.ini
+
 branches:
   only:
     - master

--- a/src/EventDispatcher/GuzzleHttpEvent.php
+++ b/src/EventDispatcher/GuzzleHttpEvent.php
@@ -4,6 +4,8 @@ namespace M6Web\Bundle\GuzzleHttpBundle\EventDispatcher;
 use Symfony\Component\EventDispatcher\Event;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Class GuzzleHttpEvent
@@ -11,6 +13,7 @@ use GuzzleHttp\Psr7\Response;
 class GuzzleHttpEvent extends Event
 {
     const EVENT_NAME = 'm6web.guzzlehttp';
+    const EVENT_ERROR_NAME = 'm6web.guzzlehttp.error';
 
     /**
      * Command start time
@@ -37,6 +40,11 @@ class GuzzleHttpEvent extends Event
     protected $response;
 
     /**
+     * @var mixed
+     */
+    protected $reason;
+
+    /**
      * @var string
      */
     protected $clientId;
@@ -48,7 +56,7 @@ class GuzzleHttpEvent extends Event
      *
      * @return $this
      */
-    public function setRequest(Request $request)
+    public function setRequest(RequestInterface $request)
     {
         $this->request = $request;
 
@@ -72,7 +80,7 @@ class GuzzleHttpEvent extends Event
      *
      * @return $this
      */
-    public function setResponse(Response $response)
+    public function setResponse(ResponseInterface $response)
     {
         $this->response = $response;
 
@@ -87,6 +95,30 @@ class GuzzleHttpEvent extends Event
     public function getResponse()
     {
         return $this->response;
+    }
+
+    /**
+     * Set reason
+     *
+     * @param mixed $reason
+     *
+     * @return $this
+     */
+    public function setReason($reason)
+    {
+        $this->reason = $reason;
+
+        return $this;
+    }
+
+    /**
+     * Return reason
+     *
+     * @return mixed
+     */
+    public function getReason()
+    {
+        return $this->reason;
     }
 
     /**

--- a/tests/Units/Middleware/EventDispatcherMiddleware.php
+++ b/tests/Units/Middleware/EventDispatcherMiddleware.php
@@ -1,0 +1,121 @@
+<?php
+namespace M6Web\Bundle\GuzzleHttpBundle\tests\Units\Middleware;
+
+use atoum\test;
+use M6Web\Bundle\GuzzleHttpBundle\Middleware\EventDispatcherMiddleware as Base;
+use M6Web\Bundle\GuzzleHttpBundle\EventDispatcher\GuzzleHttpEvent;
+
+/**
+ * Class EventDispatcherMiddleware test
+ */
+class EventDispatcherMiddleware extends test
+{
+    public function testPush()
+    {
+        // Mock dispatcher
+        $eventSend = null;
+        $dispatcherMock = new \mock\Symfony\Component\EventDispatcher\EventDispatcherInterface();
+        $dispatcherMock->getMockController()->dispatch = function($name, $event) use (&$eventSend) {
+            $eventSend = $event;
+        };
+
+        // Mock HandlerStack
+        $initCallable  = null;
+        $eventCallable = null;
+        $handlerStackMock = new \mock\GuzzleHttp\HandlerStack();
+        $handlerStackMock->getMockController()->push = function($callable, $str) use (&$initCallable, &$eventCallable) {
+            if ($str == "eventDispatcher_initEvent") {
+                $initCallable  = $callable;
+            }
+
+            if ($str == "eventDispatcher_dispatch") {
+                $eventCallable = $callable;
+            }
+        };
+
+        // Response & request
+        $requestMock  = new \mock\Psr\Http\Message\RequestInterface();
+        $responseMock = new \mock\Psr\Http\Message\ResponseInterface();
+
+        // Mock guzzle promise
+        $successCallable = null;
+        $errorCallable   = null;
+        $promiseMock = new \mock\GuzzleHttp\Promise();
+        $promiseMock->getMockController()->then = function($success, $error) use (&$successCallable, &$errorCallable) {
+            $successCallable = $success;
+            $errorCallable   = $error;
+        };
+
+        // Handler for init of event
+        $handlerInit = function($request) {
+            return $request;
+        };
+
+        // Handler for end of event
+        $handlerEvent = function() use( $promiseMock) {
+            return $promiseMock;
+        };
+
+        // 1st event : sucesss
+        $this
+            ->if($eventMid = new Base($dispatcherMock, 'id'))
+            ->then
+                ->object($eventMid->push($handlerStackMock))
+                    ->isEqualTo($handlerStackMock)
+                ->mock($handlerStackMock)
+                    ->call('push')
+                        ->twice()
+
+                ->object($callableHandler = $initCallable($handlerInit))
+                    ->isCallable()
+                ->object($callableHandler($requestMock, []))
+                    ->isEqualTo($requestMock)
+
+                ->object($callableHandler = $eventCallable($handlerEvent))
+                    ->isCallable()
+                ->variable($callableHandler($requestMock, []))
+                    ->isNull()
+                ->mock($promiseMock)
+                    ->call('then')
+                        ->once()
+
+                ->object($successCallable)
+                    ->isCallable()
+                ->object($successCallable($responseMock))
+                    ->isEqualTo($responseMock)
+                ->mock($dispatcherMock)
+                    ->call('dispatch')
+                        ->once()
+                        ->withArguments(GuzzleHttpEvent::EVENT_NAME, $eventSend)
+                            ->once()
+                         ->withArguments(GuzzleHttpEvent::EVENT_ERROR_NAME)
+                            ->never()
+
+        // 2nd event : error
+                ->object($eventMid->push($handlerStackMock))
+                    ->isEqualTo($handlerStackMock)
+
+                ->object($callableHandler = $initCallable($handlerInit))
+                    ->isCallable()
+                ->object($callableHandler($requestMock, []))
+                    ->isEqualTo($requestMock)
+
+                ->object($callableHandler = $eventCallable($handlerEvent))
+                    ->isCallable()
+                ->variable($callableHandler($requestMock, []))
+                    ->isNull()
+                ->mock($promiseMock)
+                    ->call('then')
+                        ->twice()
+
+                ->object($errorCallable)
+                    ->isCallable()
+                ->object($errorCallable("reason"))
+                    ->isEqualTo($eventMid)
+                ->mock($dispatcherMock)
+                    ->call('dispatch')
+                        ->withArguments(GuzzleHttpEvent::EVENT_ERROR_NAME, $eventSend)
+                            ->once()
+            ;
+    }
+}


### PR DESCRIPTION
After a request timeout, the event was not dispatched (no handler to catch the case) and the event stay in memory until the end of the process.

Added :
- Handler to catch request error
- New event 'error' 
- Tests

Disable xdebug for core dump with PHP 7.0 (?)