### PR TITLE
Fix dispatcher event callback for exceptions

### DIFF
--- a/src/Middleware/EventDispatcherMiddleware.php
+++ b/src/Middleware/EventDispatcherMiddleware.php
@@ -74,10 +74,10 @@ class EventDispatcherMiddleware implements MiddlewareInterface
 
                         return $response;
                     },
-                    function ($reason) use ($request) {
+                    function (\Exception $reason) use ($request) {
                         $this->sendErrorEvent($request, $reason);
 
-                        return $this;
+                        throw $reason;
                     }
                 );
             };

--- a/tests/Units/Middleware/EventDispatcherMiddleware.php
+++ b/tests/Units/Middleware/EventDispatcherMiddleware.php
@@ -110,8 +110,12 @@ class EventDispatcherMiddleware extends test
 
                 ->object($errorCallable)
                     ->isCallable()
-                ->object($errorCallable("reason"))
-                    ->isEqualTo($eventMid)
+                ->exception(
+                    function() use ($errorCallable) {
+                        $errorCallable(new \Exception("connexion error"));
+                    }
+                )
+                    ->hasMessage('connexion error')
                 ->mock($dispatcherMock)
                     ->call('dispatch')
                         ->withArguments(GuzzleHttpEvent::EVENT_ERROR_NAME, $eventSend)


### PR DESCRIPTION
Small fix after the last PR : reason is always an exception.