### PR TITLE
Remove deprecated config

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -40,7 +40,7 @@ class Configuration implements ConfigurationInterface
                             ->arrayNode('redirects')
                                 ->addDefaultsIfNotSet()
                                 ->children()
-                                    ->integerNode('max')->cannotBeEmpty()->defaultValue(5)->end()
+                                    ->integerNode('max')->defaultValue(5)->end()
                                     ->booleanNode('strict')->defaultValue(false)->end()
                                     ->booleanNode('referer')->defaultValue(true)->end()
                                     ->arrayNode('protocols')->requiresAtLeastOneElement()


### PR DESCRIPTION
This PR remove this : 
```
The Symfony\Component\Config\Definition\Builder\NumericNodeDefinition::cannotBeEmpty method is deprecated since version 2.8 and will be removed in 3.0.
```