### PR TITLE
Symfony 3 compatibilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
     "php": ">=5.5",
     "ext-curl": "*",
     "guzzlehttp/guzzle": "~6.0",
-    "symfony/symfony": "~2.6"
+    "symfony/symfony": "~2.6|~3.0"
   },
   "require-dev": {
     "atoum/atoum": "~2.1",
     "atoum/stubs": "*",
     "m6web/coke": "~1.2",
     "m6web/symfony2-coding-standard": "~2.0",
-    "symfony/dependency-injection": "~2.3",
-    "symfony/event-dispatcher": "~2.3",
-    "symfony/config" : "~2.3",
-    "symfony/yaml" : "~2.3"
+    "symfony/dependency-injection": "~2.3|~3.0",
+    "symfony/event-dispatcher": "~2.3|~3.0",
+    "symfony/config" : "~2.3|~3.0",
+    "symfony/yaml" : "~2.3|~3.0"
   },
   "autoload": {
     "psr-4": {"M6Web\\Bundle\\GuzzleHttpBundle\\": "src/"}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -40,7 +40,7 @@ class Configuration implements ConfigurationInterface
                             ->arrayNode('redirects')
                                 ->addDefaultsIfNotSet()
                                 ->children()
-                                    ->integerNode('max')->cannotBeEmpty()->defaultValue(5)->end()
+                                    ->integerNode('max')->defaultValue(5)->end()
                                     ->booleanNode('strict')->defaultValue(false)->end()
                                     ->booleanNode('referer')->defaultValue(true)->end()
                                     ->arrayNode('protocols')->requiresAtLeastOneElement()


### PR DESCRIPTION
Symfony 3 compatibilities :
- `cannotBeEmpty()` is removed