### PR TITLE
Fix curl multi handler configuration

### DIFF
--- a/src/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/src/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -163,7 +163,7 @@ class M6WebGuzzleHttpExtension extends Extension
             }
 
             $curlhandler->addMethodCall('setCache', [$cacheService, $defaultTtl, $headerTtl, $cacheServerErrors, $cacheClientErrors]);
-            $curlMultihandler->addMethodCall('setCache', [$cacheService, $defaultTtl, $headerTtl]);
+            $curlMultihandler->addMethodCall('setCache', [$cacheService, $defaultTtl, $headerTtl, $cacheServerErrors, $cacheClientErrors]);
         }
 
         $proxyHandler = new Definition('%m6web_guzzlehttp.guzzle.proxyhandler.class%');


### PR DESCRIPTION
The extension doesn't configure the curl multi handler correctly. For instance, when `cache_server_errors` is set to `false` and the multi handler is used, its value is set to the default one (`true`).

I added the missing parameters to the curl multi handler setCache method, I took example on the curl handler above.