### PR TITLE
fix service reference configuration if parameters used

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -39,7 +39,7 @@ class Configuration implements ConfigurationInterface
                                     ->booleanNode('use_header_ttl')->defaultValue(false)->end()
                                     ->booleanNode('cache_server_errors')->defaultValue(true)->end()
                                     ->booleanNode('cache_client_errors')->defaultValue(true)->end()
-                                    ->scalarNode('service')->cannotBeEmpty()->end()
+                                    ->variableNode('service')->isRequired()->cannotBeEmpty()->end()
                                 ->end()
                             ->end()
                             ->scalarNode('proxy')->defaultValue("")->end()

--- a/src/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/src/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -213,6 +213,11 @@ class M6WebGuzzleHttpExtension extends Extension
 
     protected function getServiceReference(ContainerBuilder $container, $id)
     {
+        // if $id is already a Reference (e.g. if parts of the config are defined as parameters), return it
+        if ($id instanceof Reference) {
+            return $id;
+        }
+
         if (substr($id, 0, 1) == '@') {
             return new Reference(substr($id, 1));
         }


### PR DESCRIPTION
## Why
Because the following configuration does not work:

```yml
# config.yml

parameters:
    guzzlehttp_cache_api:
        service: '@m6_redis.api'

m6web_guzzlehttp:
    clients:
        default:
            guzzlehttp_cache: '%guzzlehttp_cache_api%'
```

because when we define a service ( `@m6_redis.api` ) within a parameter ( `%guzzlehttp_cache_api%` ) symfony automatically resolves it as a `Reference` object (`variableNode()`), instead of retrieving it as a simple "string" (`scalarNode()`)