### PR TITLE
Fix Symfony 3.4 DataColector deprecation

### DIFF
--- a/src/DataCollector/GuzzleHttpDataCollector.php
+++ b/src/DataCollector/GuzzleHttpDataCollector.php
@@ -16,11 +16,7 @@ class GuzzleHttpDataCollector extends DataCollector
      */
     public function __construct()
     {
-        $this->data['guzzleHttp'] = [
-            'commands' => new \SplQueue(),
-            'has5x' => false,
-            'has4x' => false
-        ];
+        $this->reset();
     }
 
     /**
@@ -31,6 +27,15 @@ class GuzzleHttpDataCollector extends DataCollector
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
+    }
+
+    public function reset()
+    {
+        $this->data['guzzleHttp'] = [
+            'commands' => new \SplQueue(),
+            'has5x' => false,
+            'has4x' => false
+        ];
     }
 
     /**
@@ -158,7 +163,7 @@ class GuzzleHttpDataCollector extends DataCollector
     public function getRedirects()
     {
         return array_reduce(iterator_to_array($this->getCommands()), function ($redirect, $value) {
-            $redirect += $value['curl']['redirectCount'];;
+            $redirect += $value['curl']['redirectCount'];
 
             return $redirect;
         });

--- a/src/DataCollector/GuzzleHttpDataCollector.php
+++ b/src/DataCollector/GuzzleHttpDataCollector.php
@@ -29,6 +29,9 @@ class GuzzleHttpDataCollector extends DataCollector
     {
     }
 
+    /**
+     * Reset the data colector
+     */
     public function reset()
     {
         $this->data['guzzleHttp'] = [


### PR DESCRIPTION
Add the reset function and move the constructor code into.