### PR TITLE
[SF4] Use new reference notation for twig templates

### DIFF
--- a/src/Resources/config/datacollector.yml
+++ b/src/Resources/config/datacollector.yml
@@ -2,5 +2,5 @@ services:
     m6web.data_collector.guzzlehttp:
         class: M6Web\Bundle\GuzzleHttpBundle\DataCollector\GuzzleHttpDataCollector
         tags:
-            - { name: data_collector, template: 'M6WebGuzzleHttpBundle:Collector:guzzlehttp', id: 'guzzlehttp' }
+            - { name: data_collector, template: '@M6WebGuzzleHttp/Collector/guzzlehttp.html.twig', id: 'guzzlehttp' }
             - { name: kernel.event_listener, event: m6web.guzzlehttp, method: onGuzzleHttpCommand }

--- a/src/Resources/views/Collector/guzzlehttp.html.twig
+++ b/src/Resources/views/Collector/guzzlehttp.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}
@@ -23,7 +23,7 @@
         <span>{{ collector.getCacheHits }}</span>
     </div>
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': true } %}
+    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': true } %}
 {% endblock %}
 
 {% block head %}


### PR DESCRIPTION
Since 2.8, Symfony recommends to use the new notation to reference Twig templates : @BundleName/directory/filename.html.twig

So we need to fix `M6WebGuzzleHttpBundle:Collector:guzzlehttp` to
`@M6WebGuzzleHttp/Collector/guzzlehttp.html.twig`

https://symfony.com/doc/current/templating.html#referencing-templates-in-a-bundle
