### PR TITLE
fix: empty body in stream response after reading it

### DIFF
--- a/src/Handler/CacheTrait.php
+++ b/src/Handler/CacheTrait.php
@@ -147,9 +147,14 @@ trait CacheTrait
         $cached = new \SplFixedArray(5);
         $cached[0] = $statusCode;
         $cached[1] = $response->getHeaders();
-        $cached[2] = $response->getBody()->__toString();
+        $body = $response->getBody();
+        $cached[2] = $body->__toString();
         $cached[3] = $response->getProtocolVersion();
         $cached[4] = $response->getReasonPhrase();
+        // Rewind the body of the response if possible.
+        if ($body->isSeekable()) {
+            $body->rewind();
+        }
 
         return $this->cache->set(
             self::getKey($request),


### PR DESCRIPTION
## Why?
Empty body response (promise) for a first call after the cache expires (and trying to cache it). To get content,  the body of the stream response is converted to a string using the `__toString() ` method of the `GuzzleHttp\Psr7\Stream`. This method moves the stream position indicator (pointer), so the body is no longer valid for reading, which results in an invalid promise!