### PR TITLE
fix: decorate event dispatcher and invert dipatch() params

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "ext-curl": "*",
     "guzzlehttp/guzzle": "^6.3.0",
     "symfony/dependency-injection": "~2.3||~3.0||~4.0",
-    "symfony/event-dispatcher": "~2.3||~3.0||~4.0",
+    "symfony/event-dispatcher": "~4.3-stable",
     "symfony/config" : "~2.3||~3.0||~4.0",
     "symfony/yaml" : "~2.3||~3.0||~4.0"
   },

--- a/src/Handler/CacheTrait.php
+++ b/src/Handler/CacheTrait.php
@@ -231,7 +231,7 @@ trait CacheTrait
             // Send event, when cache error is ignored.
             $ignoreCacheEvent = new GuzzleCacheErrorEvent($request);
             $ignoreCacheEvent->setException($e);
-            $this->getEventDispatcher()->dispatch(GuzzleCacheErrorEvent::NAME_ERROR, $ignoreCacheEvent);
+            $this->getEventDispatcher()->dispatch($ignoreCacheEvent, GuzzleCacheErrorEvent::NAME_ERROR);
         }
 
         // no response in cache so we ask parent for response

--- a/src/Handler/CurlHandler.php
+++ b/src/Handler/CurlHandler.php
@@ -3,6 +3,7 @@ namespace M6Web\Bundle\GuzzleHttpBundle\Handler;
 
 use GuzzleHttp\Handler\CurlHandler as GuzzleCurlHandler;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 /**
  * Extends the guzzle curl handler
@@ -22,7 +23,7 @@ class CurlHandler extends GuzzleCurlHandler
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, array $options)
     {
-        $this->eventDispatcher = $eventDispatcher;
+        $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
 
         parent::__construct($options);
     }

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -3,6 +3,7 @@ namespace M6Web\Bundle\GuzzleHttpBundle\Handler;
 
 use GuzzleHttp\Handler\CurlMultiHandler as GuzzleCurlMultiHandler;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 /**
  * Extends guzzle CurlMultiHandler
@@ -22,7 +23,7 @@ class CurlMultiHandler extends GuzzleCurlMultiHandler
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, array $options)
     {
-        $this->eventDispatcher = $eventDispatcher;
+        $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
 
         parent::__construct($options);
     }

--- a/src/Middleware/EventDispatcherMiddleware.php
+++ b/src/Middleware/EventDispatcherMiddleware.php
@@ -11,6 +11,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use M6Web\Bundle\GuzzleHttpBundle\EventDispatcher\AbstractGuzzleHttpEvent;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 /**
  * Handler for event dispatching
@@ -42,7 +43,7 @@ class EventDispatcherMiddleware implements MiddlewareInterface
     public function __construct(EventDispatcherInterface $eventDispatcher, $clientId)
     {
 
-        $this->eventDispatcher = $eventDispatcher;
+        $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
         $this->events = [];
         $this->clientId = $clientId;
     }
@@ -107,7 +108,7 @@ class EventDispatcherMiddleware implements MiddlewareInterface
         $event->setClientId($this->clientId);
         $event->setExecutionStop();
         $event->setResponse($response);
-        $this->eventDispatcher->dispatch(GuzzleHttpEvent::EVENT_NAME, $event);
+        $this->eventDispatcher->dispatch($event, GuzzleHttpEvent::EVENT_NAME);
     }
 
     /**
@@ -124,6 +125,6 @@ class EventDispatcherMiddleware implements MiddlewareInterface
         $event->setClientId($this->clientId);
         $event->setExecutionStop();
         $event->setReason($reason);
-        $this->eventDispatcher->dispatch(GuzzleHttpErrorEvent::EVENT_ERROR_NAME, $event);
+        $this->eventDispatcher->dispatch($event, GuzzleHttpErrorEvent::EVENT_ERROR_NAME);
     }
 }

--- a/tests/Units/Middleware/EventDispatcherMiddleware.php
+++ b/tests/Units/Middleware/EventDispatcherMiddleware.php
@@ -17,7 +17,7 @@ class EventDispatcherMiddleware extends test
         // Mock dispatcher
         $eventSend = null;
         $dispatcherMock = new \mock\Symfony\Component\EventDispatcher\EventDispatcherInterface();
-        $dispatcherMock->getMockController()->dispatch = function($name, $event) use (&$eventSend) {
+        $dispatcherMock->getMockController()->dispatch = function($event, $name) use (&$eventSend) {
             $eventSend = $event;
         };
 
@@ -73,9 +73,9 @@ class EventDispatcherMiddleware extends test
                 ->mock($dispatcherMock)
                     ->call('dispatch')
                         ->once()
-                        ->withArguments(GuzzleHttpEvent::EVENT_NAME, $eventSend)
+                        ->withArguments($eventSend, GuzzleHttpEvent::EVENT_NAME)
                             ->once()
-                         ->withArguments(GuzzleHttpErrorEvent::EVENT_ERROR_NAME)
+                         ->withArguments($eventSend, GuzzleHttpErrorEvent::EVENT_ERROR_NAME)
                             ->never()
 
         // 2nd event : error
@@ -100,7 +100,7 @@ class EventDispatcherMiddleware extends test
                     ->hasMessage('connexion error')
                 ->mock($dispatcherMock)
                     ->call('dispatch')
-                        ->withArguments(GuzzleHttpErrorEvent::EVENT_ERROR_NAME, $eventSend)
+                        ->withArguments($eventSend, GuzzleHttpErrorEvent::EVENT_ERROR_NAME)
                             ->once()
             ;
     }


### PR DESCRIPTION
## Why
Using the bundle with event-dispatcher 4.3 was throwing an exception because the first param of `dispatch()` is expected to be an event and not a string.

## How 
- Update params order
- Use `LegacyEventDispatcherProxy` to decorate `eventDispatcher` and still be compatible with previous versions.
