### PR TITLE
fix(event-dispatcher): To use the LegacyEventDispatcherProxy we need also to use LegacyEventProxy

### DIFF
--- a/src/Middleware/EventDispatcherMiddleware.php
+++ b/src/Middleware/EventDispatcherMiddleware.php
@@ -12,6 +12,7 @@ use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use M6Web\Bundle\GuzzleHttpBundle\EventDispatcher\AbstractGuzzleHttpEvent;
 use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
+use Symfony\Component\EventDispatcher\LegacyEventProxy;
 
 /**
  * Handler for event dispatching
@@ -108,6 +109,7 @@ class EventDispatcherMiddleware implements MiddlewareInterface
         $event->setClientId($this->clientId);
         $event->setExecutionStop();
         $event->setResponse($response);
+        $event = new LegacyEventProxy($event);
         $this->eventDispatcher->dispatch($event, GuzzleHttpEvent::EVENT_NAME);
     }
 
@@ -125,6 +127,7 @@ class EventDispatcherMiddleware implements MiddlewareInterface
         $event->setClientId($this->clientId);
         $event->setExecutionStop();
         $event->setReason($reason);
+        $event = new LegacyEventProxy($event);
         $this->eventDispatcher->dispatch($event, GuzzleHttpErrorEvent::EVENT_ERROR_NAME);
     }
 }


### PR DESCRIPTION
if `LegacyEventDispatcherProxy` in the dispatch method try to invoke the `Symfony\Component\EventDispatcher\Debug\WrappedListener` which wait for `Symfony\Component\EventDispatcher\Event` but it receive a`Symfony\Contracts\EventDispatcher\Event` (from AbstractGuzzleHttpEvent)

We need this Legacy event 'decoration' 