### PR TITLE
feat(symfony5): support Symfony5 and restore travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,32 @@
+# inspired from https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/.travis.yml
+
 language: php
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-
-before_script:
-  - phpenv config-rm xdebug.ini
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 branches:
   only:
     - master
 
+matrix:
+  include:
+    - php: 7.1
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
+  allow_failures:
+    # @TODO remove when atoum will support php7.4
+    - php: 7.4
+
+before_install:
+  - phpenv config-rm xdebug.ini || true
+
 install:
-  - composer install -n --dev
+  - composer update $COMPOSER_FLAGS --prefer-dist -n
+  - if [ "$COMPOSER_PREFER" = "lowest" ]; then composer update --prefer-lowest -n; fi;
 
 script:
   - bin/coke

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ Require the bundle in your composer.json file :
 ```json
 {
     "require": {
-        "m6web/guzzle-http-bundle": "~2.0"
+        "m6web/guzzle-http-bundle": "~3.0"
     }
 }
 ```
+
+> For older Symfony versions, you can try to install an older version of this bundle.
 
 Register the bundle in your kernel :
 

--- a/composer.json
+++ b/composer.json
@@ -12,19 +12,20 @@
     }
   ],
   "require": {
-    "php": ">=7.0",
+    "php": ">=7.1",
     "ext-curl": "*",
-    "guzzlehttp/guzzle": "^6.3.0",
-    "symfony/dependency-injection": "~2.3||~3.0||~4.0",
-    "symfony/event-dispatcher": "~4.3-stable",
-    "symfony/config" : "~2.3||~3.0||~4.0",
-    "symfony/yaml" : "~2.3||~3.0||~4.0"
+    "guzzlehttp/guzzle": "~6.3",
+    "symfony/config" : "~4.3||~5.0",
+    "symfony/dependency-injection": "~3.4||~4.3||~5.0",
+    "symfony/event-dispatcher": "~4.3||~5.0",
+    "symfony/http-kernel": "~3.4||~4.3||~5.0",
+    "symfony/yaml" : "~3.4||~4.3||~5.0"
   },
   "require-dev": {
-    "atoum/atoum": "^2.8||^3.0",
+    "atoum/atoum": "~3.1",
     "atoum/stubs": "*",
-    "m6web/coke": "~1.2||^2.2",
-    "m6web/symfony2-coding-standard": "~2.0||^3.3"
+    "m6web/coke": "~2.2",
+    "m6web/symfony2-coding-standard": "~3.3"
   },
   "autoload": {
     "psr-4": {"M6Web\\Bundle\\GuzzleHttpBundle\\": "src/"}

--- a/src/DataCollector/GuzzleHttpDataCollector.php
+++ b/src/DataCollector/GuzzleHttpDataCollector.php
@@ -25,7 +25,7 @@ class GuzzleHttpDataCollector extends DataCollector
      * @param Response   $response  The response object
      * @param \Exception $exception An exception
      */
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    public function collect(Request $request, Response $response, \Throwable $exception = null)
     {
     }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,10 +17,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('m6web_guzzlehttp');
+        $treeBuilder = new TreeBuilder('m6web_guzzlehttp');
 
-        $rootNode
+        $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('clients')
                     ->isRequired()

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -2,6 +2,7 @@
 namespace M6Web\Bundle\GuzzleHttpBundle\Handler;
 
 use GuzzleHttp\Handler\CurlFactory as GuzzleCurlFactory;
+// @TODO use something else since EasyHandle class is @internal (=> BC is not ensured)
 use GuzzleHttp\Handler\EasyHandle;
 
 /**

--- a/src/Handler/CurlHandler.php
+++ b/src/Handler/CurlHandler.php
@@ -3,7 +3,6 @@ namespace M6Web\Bundle\GuzzleHttpBundle\Handler;
 
 use GuzzleHttp\Handler\CurlHandler as GuzzleCurlHandler;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 /**
  * Extends the guzzle curl handler
@@ -23,7 +22,7 @@ class CurlHandler extends GuzzleCurlHandler
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, array $options)
     {
-        $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
+        $this->eventDispatcher = $eventDispatcher;
 
         parent::__construct($options);
     }

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -3,7 +3,6 @@ namespace M6Web\Bundle\GuzzleHttpBundle\Handler;
 
 use GuzzleHttp\Handler\CurlMultiHandler as GuzzleCurlMultiHandler;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 /**
  * Extends guzzle CurlMultiHandler
@@ -23,7 +22,7 @@ class CurlMultiHandler extends GuzzleCurlMultiHandler
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, array $options)
     {
-        $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
+        $this->eventDispatcher = $eventDispatcher;
 
         parent::__construct($options);
     }

--- a/src/M6WebGuzzleHttpBundle.php
+++ b/src/M6WebGuzzleHttpBundle.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class M6WebGuzzleHttpBundle extends Bundle
 {
     /**
-     * @return DependencyInjection\M6WebCassandraExtension|null|\Symfony\Component\DependencyInjection\Extension\ExtensionInterface
+     * {@inheritdoc}
      */
     public function getContainerExtension()
     {
@@ -19,7 +19,7 @@ class M6WebGuzzleHttpBundle extends Bundle
     }
 
     /**
-     * @param ContainerBuilder $container
+     * {@inheritdoc}
      */
     public function build(ContainerBuilder $container)
     {

--- a/src/Middleware/EventDispatcherMiddleware.php
+++ b/src/Middleware/EventDispatcherMiddleware.php
@@ -2,17 +2,11 @@
 namespace M6Web\Bundle\GuzzleHttpBundle\Middleware;
 
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Middleware;
-use GuzzleHttp\Psr7\Response;
 use M6Web\Bundle\GuzzleHttpBundle\EventDispatcher\GuzzleHttpErrorEvent;
 use M6Web\Bundle\GuzzleHttpBundle\EventDispatcher\GuzzleHttpEvent;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use M6Web\Bundle\GuzzleHttpBundle\EventDispatcher\AbstractGuzzleHttpEvent;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
-use Symfony\Component\EventDispatcher\LegacyEventProxy;
 
 /**
  * Handler for event dispatching
@@ -43,8 +37,7 @@ class EventDispatcherMiddleware implements MiddlewareInterface
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, $clientId)
     {
-
-        $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
+        $this->eventDispatcher = $eventDispatcher;
         $this->events = [];
         $this->clientId = $clientId;
     }
@@ -109,7 +102,6 @@ class EventDispatcherMiddleware implements MiddlewareInterface
         $event->setClientId($this->clientId);
         $event->setExecutionStop();
         $event->setResponse($response);
-        $event = new LegacyEventProxy($event);
         $this->eventDispatcher->dispatch($event, GuzzleHttpEvent::EVENT_NAME);
     }
 
@@ -127,7 +119,6 @@ class EventDispatcherMiddleware implements MiddlewareInterface
         $event->setClientId($this->clientId);
         $event->setExecutionStop();
         $event->setReason($reason);
-        $event = new LegacyEventProxy($event);
         $this->eventDispatcher->dispatch($event, GuzzleHttpErrorEvent::EVENT_ERROR_NAME);
     }
 }

--- a/tests/Units/DependencyInjection/M6WebGuzzleHttpExtension.php
+++ b/tests/Units/DependencyInjection/M6WebGuzzleHttpExtension.php
@@ -275,10 +275,7 @@ class M6WebGuzzleHttpExtension extends test
 
     public function testEventDispatcherMiddleWare()
     {
-        $mockDispatcher = new \mock\Symfony\Component\EventDispatcher\EventDispatcherInterface();
-
         $container = $this->getContainerForConfiguration('default-config');
-        $container->set('event_dispatcher', $mockDispatcher);
         $container->compile();
 
         $this
@@ -289,7 +286,7 @@ class M6WebGuzzleHttpExtension extends test
             ])
             ->and($rep = Promise\unwrap($promises))
             ->then
-                ->mock($mockDispatcher)
+                ->mock($container->get('event_dispatcher'))
                     ->call('dispatch')
                         ->twice()
         ;
@@ -297,10 +294,7 @@ class M6WebGuzzleHttpExtension extends test
 
     public function testEventDispatcherMultiClient()
     {
-        $mockDispatcher = new \mock\Symfony\Component\EventDispatcher\EventDispatcherInterface();
-
         $container = $this->getContainerForConfiguration('multiclient-config');
-        $container->set('event_dispatcher', $mockDispatcher);
         $container->compile();
 
         $this
@@ -313,7 +307,7 @@ class M6WebGuzzleHttpExtension extends test
             ->and($rep = Promise\unwrap($promises))
             ->and($client2->get('http://httpbin.org'))
             ->then
-                ->mock($mockDispatcher)
+                ->mock($container->get('event_dispatcher'))
                 ->call('dispatch')
                     ->exactly(3)
         ;
@@ -527,7 +521,11 @@ class M6WebGuzzleHttpExtension extends test
             $container = $this->getContainerBuilder();
         }
 
-        $container->set('event_dispatcher', new \mock\Symfony\Component\EventDispatcher\EventDispatcherInterface());
+        $mockDispatcher = new \mock\Symfony\Component\EventDispatcher\EventDispatcherInterface();
+        $mockDispatcher->getMockController()->dispatch = function($event) {
+            return $event;
+        };
+        $container->set('event_dispatcher', $mockDispatcher);
         $container->set('cache_service', new \mock\M6Web\Bundle\GuzzleHttpBundle\Cache\CacheInterface());
         $container->set('cache_service2', new \mock\M6Web\Bundle\GuzzleHttpBundle\Cache\CacheInterface());
         $container->registerExtension($extension);

--- a/tests/Units/Middleware/EventDispatcherMiddleware.php
+++ b/tests/Units/Middleware/EventDispatcherMiddleware.php
@@ -5,7 +5,6 @@ use atoum\test;
 use M6Web\Bundle\GuzzleHttpBundle\EventDispatcher\GuzzleHttpErrorEvent;
 use M6Web\Bundle\GuzzleHttpBundle\EventDispatcher\GuzzleHttpEvent;
 use M6Web\Bundle\GuzzleHttpBundle\Middleware\EventDispatcherMiddleware as Base;
-use M6Web\Bundle\GuzzleHttpBundle\EventDispatcher\AbstractGuzzleHttpEvent;
 
 /**
  * Class EventDispatcherMiddleware test
@@ -19,6 +18,7 @@ class EventDispatcherMiddleware extends test
         $dispatcherMock = new \mock\Symfony\Component\EventDispatcher\EventDispatcherInterface();
         $dispatcherMock->getMockController()->dispatch = function($event, $name) use (&$eventSend) {
             $eventSend = $event;
+            return $event;
         };
 
         // Mock HandlerStack


### PR DESCRIPTION
## Why?
- we say in composer.json that we support `>php7.0` but our bundle contains code only compatible with `>php7.1` (nullable typing)... so we already dropped support for php7.0 💃 
- our CI is failing for a while now... because it has been deactivated somehow 🤷‍♂ 
- we depend on `LegacyEventProxy` which is a Symfony `@internal` class... and has been brutally removed in Symfony 5

## How?
- supports php7.1 to php7.3 in our CI (php7.4 may work fine but atoum is not compatible with it yet... so we can't test it well)
- enable support for Symfony 5 ~(we didn't test it in a real symfony5 project yet... but at least our tests passes 🤷‍♂)~ (see REAL TESTING section)
- drop support for the old `EventDispatcherInterface::dispatch` param orders
- drop support for unsupported symfony version [https://symfony.com/releases](https://symfony.com/releases)
- drop support for symfony/config < 4.3 (because we use the new `TreeBuilder::getRootNode()` function which came with `4.2`... but since `4.2` is not a supported version, we support only `4.3`)


=> of course this will be a major update -> `v3.0.0`


## REAL TESTING
I made a simple project to make sure the project does not throw any exception nor deprecation using Symfony5 => https://github.com/Oliboy50/sf5-testing

![Capture d’écran 2019-12-09 à 17 51 17](https://user-images.githubusercontent.com/2571084/70455842-43f4c300-1aad-11ea-9be4-deb858f7dc1e.png)

<img width="659" alt="Capture d’écran 2019-12-09 à 17 57 43" src="https://user-images.githubusercontent.com/2571084/70455922-6be42680-1aad-11ea-97de-88eb66488a87.png">
