### PR TITLE
fix(cache): rewind the response stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 vendor
 composer.lock
 bin
+
+###> friendsofphp/php-cs-fixer ###
+/.php_cs
+/.php_cs.cache
+###< friendsofphp/php-cs-fixer ###

--- a/src/Handler/CacheTrait.php
+++ b/src/Handler/CacheTrait.php
@@ -137,6 +137,10 @@ trait CacheTrait
         $cached[3] = $response->getProtocolVersion();
         $cached[4] = $response->getReasonPhrase();
 
+        // we need to rewind the response body, because the response
+        // is a stream and is already read before
+        $response->getBody()->rewind();
+
         return $this->cache->set(
             self::getKey($request),
             serialize($cached),

--- a/src/Middleware/EventDispatcherMiddleware.php
+++ b/src/Middleware/EventDispatcherMiddleware.php
@@ -14,19 +14,13 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class EventDispatcherMiddleware implements MiddlewareInterface
 {
-    /**
-     * @var EventDispatcherInterface
-     */
+    /** @var EventDispatcherInterface */
     protected $eventDispatcher;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $events;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $clientId;
 
     /**


### PR DESCRIPTION
## Why?
If we enable the cache feature. And when the cache does not exist. The answer is empty because it is a stream that is already read during caching.

## How?
Rewind the response for get information of stream.

